### PR TITLE
use TryGetFullName to get the full name of the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+* Handle types without a FullName more gracefully in the EmptyStringAnalyzer. [#48](https://github.com/ionide/ionide-analyzers/pull/48)
+
 ## 0.5.0 - 2023-11-23
 
 ### Changed

--- a/src/Ionide.Analyzers/Suggestion/EmptyStringAnalyzer.fs
+++ b/src/Ionide.Analyzers/Suggestion/EmptyStringAnalyzer.fs
@@ -6,12 +6,11 @@ open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
 
 let (|EmptyStringConst|_|) (e: FSharpExpr) =
-    if e.Type.ErasedType.BasicQualifiedName = "System.String" then
-        match e with
-        | FSharpExprPatterns.Const(o, _type) when not (isNull o) && (string o).Length = 0 -> Some()
-        | _ -> None
-    else
-        None
+    let name = e.Type.ErasedType.TypeDefinition.TryGetFullName()
+
+    match name, e with
+    | Some("System.String"), FSharpExprPatterns.Const(o, _type) when not (isNull o) && (string o).Length = 0 -> Some()
+    | _ -> None
 
 let invalidStringFunctionUseAnalyzer (typedTree: FSharpImplementationFileContents) =
     let ranges = ResizeArray<range>()

--- a/tests/Ionide.Analyzers.Tests/Suggestion/EmptyStringAnalyzerTests.fs
+++ b/tests/Ionide.Analyzers.Tests/Suggestion/EmptyStringAnalyzerTests.fs
@@ -138,3 +138,21 @@ let x = s.Length = 0
         let! msgs = emptyStringCliAnalyzer ctx
         Assert.IsEmpty msgs
     }
+
+[<Test>]
+let ``Handle types without a FullName gracefully`` () =
+    async {
+        let source =
+            """
+module M
+
+let f () =
+    let mutable bom = Array.zeroCreate 3
+    let mutable bom2 = Array.zeroCreate 3
+    bom = bom2
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = emptyStringCliAnalyzer ctx
+        Assert.IsEmpty msgs
+    }


### PR DESCRIPTION
This was one of the `"unhandled expression at ` messages. Mea culpa.