### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 0.5.1 - 2023-12-06
 
 ### Fixed
 * Handle types without a FullName more gracefully in the EmptyStringAnalyzer. [#48](https://github.com/ionide/ionide-analyzers/pull/48)

--- a/src/Ionide.Analyzers/Suggestion/HandleOptionGracefullyAnalyzer.fs
+++ b/src/Ionide.Analyzers/Suggestion/HandleOptionGracefullyAnalyzer.fs
@@ -19,7 +19,7 @@ let optionGetAnalyzer (ctx: CliContext) =
                     let fullyQualifiedCall =
                         let fullName =
                             mfv.DeclaringEntity
-                            |> Option.map (fun e -> e.TryFullName)
+                            |> Option.map (fun e -> e.TryGetFullName())
                             |> Option.flatten
                             |> Option.defaultValue ""
 


### PR DESCRIPTION
The rest of the exceptions we see are from [here](https://github.com/dotnet/fsharp/blob/b311526f48a5a6e65079dc2e6942349509e3014d/src/Compiler/Symbols/Exprs.fs#L1177) when the TAST is walked.
Need to look deeper if we can do something about that.