### PR TITLE
Tweak attribute handling in StructDiscriminatedUnionAnalyzer and add …

### DIFF
--- a/src/Ionide.Analyzers/Suggestion/StructDiscriminatedUnionAnalyzer.fs
+++ b/src/Ionide.Analyzers/Suggestion/StructDiscriminatedUnionAnalyzer.fs
@@ -26,7 +26,9 @@ let private hasStructAttribute (attrs: SynAttributes) =
         attrList.Attributes
         |> List.exists (fun a ->
             match List.tryLast a.TypeName.LongIdent with
-            | Some structIdent -> structIdent.idText.StartsWith("Struct", StringComparison.Ordinal)
+            | Some structIdent ->
+                structIdent.idText.Equals("Struct", StringComparison.Ordinal)
+                || structIdent.idText.Equals("StructAttribute", StringComparison.Ordinal)
             | _ -> false
         )
     )

--- a/tests/Ionide.Analyzers.Tests/Suggestion/StructDiscriminatedUnionAnalyzerTests.fs
+++ b/tests/Ionide.Analyzers.Tests/Suggestion/StructDiscriminatedUnionAnalyzerTests.fs
@@ -52,6 +52,45 @@ type Foo =
     }
 
 [<Test>]
+let ``negative: du is already struct (full StructAttribute name)`` () =
+    async {
+        let source =
+            """module Lib
+
+[<StructAttribute>]
+type Foo =
+    | Bar
+    | Barry
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = structDiscriminatedUnionCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+// A special test case for https://github.com/ionide/ionide-analyzers/issues/102
+[<Test>]
+let ``du with a StructuredFormatDisplay attribute`` () =
+    async {
+        let source =
+            """module Lib
+
+[<StructuredFormatDisplay("{DisplayText}")>]
+type Foo =
+    | Bar
+    | Barry
+
+    member this.DisplayText = ""
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = structDiscriminatedUnionCliAnalyzer ctx
+        Assert.That(msgs, Is.Not.Empty)
+        let msg = msgs[0]
+        Assert.That(Assert.messageContains message msg, Is.True)
+    }
+
+[<Test>]
 let ``du with only primitive field values`` () =
     async {
         let source =


### PR DESCRIPTION
…more tests

refs https://github.com/ionide/ionide-analyzers/issues/102

Is it reasonable to test for both ```[<Struct>]``` and ```[<StructAttribute>]``` ?