### PR TITLE
bump FCS and Analyzer SDK to .NET 9 versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsharp-analyzers": {
-      "version": "0.27.0",
+      "version": "0.28.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Analyzers
         continue-on-error: true
-        run: dotnet fsharp-analyzers --project ./src/Ionide.Analyzers/Ionide.Analyzers.fsproj --project ./tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj --analyzers-path ./src/Ionide.Analyzers/bin/Release/net6.0 --report ./report.sarif
+        run: dotnet fsharp-analyzers --project ./src/Ionide.Analyzers/Ionide.Analyzers.fsproj --project ./tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj --analyzers-path ./src/Ionide.Analyzers/bin/Release/net8.0 --report ./report.sarif
         if: matrix.os == 'ubuntu-latest'
 
       - name: Upload SARIF file

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="FSharp.Core" Version="[8.0.400]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.400]" />
+    <PackageVersion Include="FSharp.Core" Version="[9.0.100]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.9.100]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
@@ -14,7 +14,7 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.374" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.27.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.27.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.28.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.28.0]" />
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
+++ b/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Tailcalls>true</Tailcalls>


### PR DESCRIPTION
Also bump TFM to net8.0 because those packages require it.

Fixes #127 