### PR TITLE
Update FSharp.Analyzers.SDK 0.32.0 and Fixed ReturnStructPartialActivePatternAnalyzer ProjectOptions when using TransparentCompiler in EditorContext

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsharp-analyzers": {
-      "version": "0.31.0",
+      "version": "0.32.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.374" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.31.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.31.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.32.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.32.0]" />
   </ItemGroup>
 </Project>

--- a/src/Ionide.Analyzers/LanguageVersionShim.fs
+++ b/src/Ionide.Analyzers/LanguageVersionShim.fs
@@ -98,12 +98,14 @@ module LanguageVersionShim =
     /// <returns></returns>
     let private defaultLanguageVersion = lazy (LanguageVersionShim("latest"))
 
-    /// <summary>Tries to parse out "--langversion:" from OtherOptions if it can't find it, returns defaultLanguageVersion</summary>
-    /// <param name="fpo">The FSharpProjectOptions to use</param>
-    /// <returns>A LanguageVersionShim from the parsed "--langversion:" or defaultLanguageVersion </returns>
-    let fromFSharpProjectOptions (fpo: FSharpProjectOptions) =
-        fpo.OtherOptions
-        |> Array.tryFind (fun x -> x.StartsWith("--langversion:", StringComparison.Ordinal))
+    let fromOtherOptions (otherOptions: string seq) =
+        otherOptions
+        |> Seq.tryFind (fun x -> x.StartsWith("--langversion:", StringComparison.Ordinal))
         |> Option.map (fun x -> x.Split(":")[1])
         |> Option.map (fun x -> LanguageVersionShim(x))
         |> Option.defaultWith (fun () -> defaultLanguageVersion.Value)
+
+    /// <summary>Tries to parse out "--langversion:" from OtherOptions if it can't find it, returns defaultLanguageVersion</summary>
+    /// <param name="fpo">The FSharpProjectOptions to use</param>
+    /// <returns>A LanguageVersionShim from the parsed "--langversion:" or defaultLanguageVersion </returns>
+    let fromFSharpProjectOptions (fpo: FSharpProjectOptions) = fpo.OtherOptions |> fromOtherOptions

--- a/src/Ionide.Analyzers/Performance/ReturnStructPartialActivePatternAnalyzer.fs
+++ b/src/Ionide.Analyzers/Performance/ReturnStructPartialActivePatternAnalyzer.fs
@@ -210,10 +210,11 @@ let runIfLanguageFeatureIsSupported
     (sourceText: ISourceText)
     (parsedInput: ParsedInput)
     (checkResults: FSharpCheckFileResults)
+    (projectOptions: AnalyzerProjectOptions)
     : Message list
     =
     let languageVersionShim =
-        LanguageVersionShim.fromFSharpProjectOptions checkResults.ProjectContext.ProjectOptions
+        LanguageVersionShim.fromOtherOptions projectOptions.OtherOptions
 
     if not (languageVersionShim.SupportsFeature(languageFeature.Value)) then
         []
@@ -229,6 +230,7 @@ let returnStructPartialActivePatternCliAnalyzer: Analyzer<CliContext> =
                     context.SourceText
                     context.ParseFileResults.ParseTree
                     context.CheckFileResults
+                    context.ProjectOptions
         }
 
 [<EditorAnalyzer(name, shortDescription, helpUri)>]
@@ -239,5 +241,9 @@ let returnStructPartialActivePatternEditorAnalyzer: Analyzer<EditorContext> =
             | None -> return []
             | Some checkResults ->
                 return
-                    runIfLanguageFeatureIsSupported context.SourceText context.ParseFileResults.ParseTree checkResults
+                    runIfLanguageFeatureIsSupported
+                        context.SourceText
+                        context.ParseFileResults.ParseTree
+                        checkResults
+                        context.ProjectOptions
         }


### PR DESCRIPTION
Closes #147 