### PR TITLE
Update Ionide.KeepAChangelog.Tasks to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.17.0 - 2026-08-15
+## [0.17.0] - 2026-08-15
 
 ### Changed
 
 * Rename MixedPipeDirectionAnalyzer to MixedFlowDirectionAnalyzer and extend it to cover mixed pipe and composition directions.
 
-## 0.16.0 - 2026-08-11
+## [0.16.0] - 2026-08-11
 
 ### Added
 
@@ -16,85 +16,85 @@
 
 * Update FSharp.Analyzers.SDK to `0.37.2`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.37.2) for details. [#180](https://github.com/ionide/ionide-analyzers/pull/180)
 
-## 0.15.0 - 2026-03-13
+## [0.15.0] - 2026-03-13
 
 ### Fixed
 
 * Update FSharp.Analyzers.SDK to `0.36.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.36.0) for details. [#168](https://github.com/ionide/ionide-analyzers/pull/168)
 
-## 0.14.11 - 2026-01-25
+## [0.14.11] - 2026-01-25
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.35.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.35.0) for details. [#166](https://github.com/ionide/ionide-analyzers/pull/166)
 
-## 0.14.10 - 2025-11-11
+## [0.14.10] - 2025-11-11
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.34.1`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.34.1) for details. [#164](https://github.com/ionide/ionide-analyzers/pull/164)
 
-## 0.14.9 - 2025-10-19
+## [0.14.9] - 2025-10-19
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.33.1`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.33.1) for details. [#163](https://github.com/ionide/ionide-analyzers/pull/163)
 
-## 0.14.8 - 2025-10-19
+## [0.14.8] - 2025-10-19
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.33.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.33.0) for details. [#162](https://github.com/ionide/ionide-analyzers/pull/162)
 
-## 0.14.7 - 2025-08-02
+## [0.14.7] - 2025-08-02
 
 ### Fixed
 
 * Update FSharp.Analyzers.SDK to `0.32.1`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.32.1) for details.
 
-## 0.14.6 - 2025-07-12
+## [0.14.6] - 2025-07-12
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK `0.32.0` and Fixed ReturnStructPartialActivePatternAnalyzer ProjectOptions when using TransparentCompiler in EditorContext [#152](https://github.com/ionide/ionide-analyzers/pull/152)
 
-## 0.14.5 - 2025-05-17
+## [0.14.5] - 2025-05-17
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.31.0`. [#146](https://github.com/ionide/ionide-analyzers/pull/146)
 
-## 0.14.4 - 2025-03-25
+## [0.14.4] - 2025-03-25
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.30.0`. [#144](https://github.com/ionide/ionide-analyzers/pull/144)
 
-## 0.14.2 - 2025-03-18
+## [0.14.2] - 2025-03-18
 
 ### Fixed
 
 * InvalidOperationException on generic discriminated unions. [#142](https://github.com/ionide/ionide-analyzers/issues/142)
 
-## 0.14.1 - 2025-03-06
+## [0.14.1] - 2025-03-06
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.29.1`. [#141](https://github.com/ionide/ionide-analyzers/pull/141)
 
-## 0.14.0 - 2025-02-12  
+## [0.14.0] - 2025-02-12
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.29.0`. [#139](https://github.com/ionide/ionide-analyzers/pull/139)
 
-## 0.13.1 - 2025-01-08
+## [0.13.1] - 2025-01-08
 
 ### Fixed
 
 * InvalidOperationException on some DUs. [#128](https://github.com/ionide/ionide-analyzers/issues/128)
 
-## 0.13.0 - 2024-11-19
+## [0.13.0] - 2024-11-19
 
 ### Added
 
@@ -105,23 +105,25 @@
 
 * Support for .NET 6 and .NET 7
 
-## 0.12.0 - 2024-08-18
+## [0.12.0] - 2024-08-18
 
 ### Changed
 
-* Update FSharp.Analyzers.SDK to `0.27.0`. [#111](https://github.com/ionide/ionide-analyzers/pull/110)
+* Update FSharp.Analyzers.SDK to `0.27.0`. [#111](https://github.com/ionide/ionide-analyzers/pull/111)
 
-## 0.11.1 - 2024-08-06
+## [0.11.1] - 2024-08-06
+
+### Changed
 
 * Update FSharp.Analyzers.SDK to `0.26.1`. [#110](https://github.com/ionide/ionide-analyzers/pull/110)
 
-## 0.11.0 - 2024-05-15
+## [0.11.0] - 2024-05-15
 
 ### Changed
 
 * Update FSharp.Analyzers.SDK to `0.26.0`, FSharp.Compiler.Service to `43.8.300`, and FSharp.Core to `8.0.300`. [#93](https://github.com/ionide/ionide-analyzers/pull/93)
 
-## 0.10.0 - 2024-03-29
+## [0.10.0] - 2024-03-29
 
 ### Added
 * HeadConsEmptyListPatternAnalyzer. [#85](https://github.com/ionide/ionide-analyzers/pull/85)
@@ -131,17 +133,17 @@
 * EqualsNullAnalyzer [#85](https://github.com/ionide/ionide-analyzers/pull/85)
 * StructDiscriminatedUnionAnalyzer. [#85](https://github.com/ionide/ionide-analyzers/pull/85)
 
-## 0.9.0 - 2024-02-15
+## [0.9.0] - 2024-02-15
 
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.25.0`. [#68](https://github.com/ionide/ionide-analyzers/pull/75)
 
-## 0.8.0 - 2024-01-30
+## [0.8.0] - 2024-01-30
 
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.24.0`. [#68](https://github.com/ionide/ionide-analyzers/pull/75)
 
-## 0.7.0 - 2024-01-10
+## [0.7.0] - 2024-01-10
 
 ### Added
 * Add fix-support to the CopyAndUpdateRecordChangesAllFieldsAnalyzer. [#68](https://github.com/ionide/ionide-analyzers/pull/68)
@@ -149,40 +151,40 @@
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.23.0`. [#68](https://github.com/ionide/ionide-analyzers/pull/68)
 
-## 0.6.1 - 2024-01-01
+## [0.6.1] - 2024-01-01
 
 ### Added
 * Add editor support to all analyzers. [#64](https://github.com/ionide/ionide-analyzers/pull/64)
 
-## 0.6.0 - 2023-12-20
+## [0.6.0] - 2023-12-20
 
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.22.0`. [#60](https://github.com/ionide/ionide-analyzers/pull/60)
 
-## 0.5.1 - 2023-12-06
+## [0.5.1] - 2023-12-06
 
 ### Fixed
 * Handle types without a FullName more gracefully in the EmptyStringAnalyzer. [#48](https://github.com/ionide/ionide-analyzers/pull/48)
 * Handle types without a FullName more gracefully in the HandleOptionGracefullyAnalyzer. [#50](https://github.com/ionide/ionide-analyzers/pull/50)
 
-## 0.5.0 - 2023-11-23
+## [0.5.0] - 2023-11-23
 
 ### Changed
 * Reworks `ReplaceOptionGetWithGracefulHandlingAnalyzer` to handle ValueOption's and `.Value` member access. [#33](https://github.com/ionide/ionide-analyzers/pull/33) 
 * Reworks `SquareBracketArrayAnalyzer` to handle all generic types that should be postfixed. [#39](https://github.com/ionide/ionide-analyzers/pull/39)
 * Update FSharp.Analyzers.SDK to `0.21.0`. [#45](https://github.com/ionide/ionide-analyzers/pull/45)
 
-## 0.4.0 - 2023-11-15
+## [0.4.0] - 2023-11-15
 
 ### Added
 * ReplaceOptionGetWithGracefulHandlingAnalyzer [#32](https://github.com/ionide/ionide-analyzers/pull/32)
 
-## 0.3.0 - 2023-11-13
+## [0.3.0] - 2023-11-13
 
 ### Changed
 * Update FSharp.Analyzers.SDK to v0.20.0. [#26](https://github.com/ionide/ionide-analyzers/pull/26)
 
-## 0.2.0 - 2023-11-09
+## [0.2.0] - 2023-11-09
 
 ### Fixed
 * Fix analyzers urls. [#19](https://github.com/ionide/ionide-analyzers/pull/19)
@@ -192,12 +194,12 @@
 * Support for referencing a local analyzers SDK. [#18](https://github.com/ionide/ionide-analyzers/pull/18)
 * EmptyStringAnalyzer. [#20](https://github.com/ionide/ionide-analyzers/pull/20)
 
-## 0.1.1 - 2023-11-07
+## [0.1.1] - 2023-11-07
 
 ### Fixed
 * Update NuGet properties. [#14](https://github.com/ionide/ionide-analyzers/pull/14)
 
-## 0.1.0 - 2023-11-07
+## [0.1.0] - 2023-11-07
 
 ### Added
 * Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,78 +1,78 @@
 # Changelog
 
-## 0.14.11 - 2026-01-25
+## [0.14.11] - 2026-01-25
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.35.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.35.0) for details. [#166](https://github.com/ionide/ionide-analyzers/pull/166)
 
-## 0.14.10 - 2025-11-11
+## [0.14.10] - 2025-11-11
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.34.1`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.34.1) for details. [#164](https://github.com/ionide/ionide-analyzers/pull/164)
 
-## 0.14.9 - 2025-10-19
+## [0.14.9] - 2025-10-19
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.33.1`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.33.1) for details. [#163](https://github.com/ionide/ionide-analyzers/pull/163)
 
-## 0.14.8 - 2025-10-19
+## [0.14.8] - 2025-10-19
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK to `0.33.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.33.0) for details. [#162](https://github.com/ionide/ionide-analyzers/pull/162)
 
-## 0.14.7 - 2025-08-02
+## [0.14.7] - 2025-08-02
 
 ### Fixed
 
 * Update FSharp.Analyzers.SDK to `0.32.1`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.32.1) for details.
 
-## 0.14.6 - 2025-07-12
+## [0.14.6] - 2025-07-12
 
 ### Fixed 
 
 * Update FSharp.Analyzers.SDK `0.32.0` and Fixed ReturnStructPartialActivePatternAnalyzer ProjectOptions when using TransparentCompiler in EditorContext [#152](https://github.com/ionide/ionide-analyzers/pull/152)
 
-## 0.14.5 - 2025-05-17
+## [0.14.5] - 2025-05-17
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.31.0`. [#146](https://github.com/ionide/ionide-analyzers/pull/146)
 
-## 0.14.4 - 2025-03-25
+## [0.14.4] - 2025-03-25
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.30.0`. [#144](https://github.com/ionide/ionide-analyzers/pull/144)
 
-## 0.14.2 - 2025-03-18
+## [0.14.2] - 2025-03-18
 
 ### Fixed
 
 * InvalidOperationException on generic discriminated unions. [#142](https://github.com/ionide/ionide-analyzers/issues/142)
 
-## 0.14.1 - 2025-03-06
+## [0.14.1] - 2025-03-06
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.29.1`. [#141](https://github.com/ionide/ionide-analyzers/pull/141)
 
-## 0.14.0 - 2025-02-12  
+## [0.14.0] - 2025-02-12
 
 ### Changed
 
 * Bump FSharp.Analyzers.SDK to `0.29.0`. [#139](https://github.com/ionide/ionide-analyzers/pull/139)
 
-## 0.13.1 - 2025-01-08
+## [0.13.1] - 2025-01-08
 
 ### Fixed
 
 * InvalidOperationException on some DUs. [#128](https://github.com/ionide/ionide-analyzers/issues/128)
 
-## 0.13.0 - 2024-11-19
+## [0.13.0] - 2024-11-19
 
 ### Added
 
@@ -83,23 +83,25 @@
 
 * Support for .NET 6 and .NET 7
 
-## 0.12.0 - 2024-08-18
+## [0.12.0] - 2024-08-18
 
 ### Changed
 
-* Update FSharp.Analyzers.SDK to `0.27.0`. [#111](https://github.com/ionide/ionide-analyzers/pull/110)
+* Update FSharp.Analyzers.SDK to `0.27.0`. [#111](https://github.com/ionide/ionide-analyzers/pull/111)
 
-## 0.11.1 - 2024-08-06
+## [0.11.1] - 2024-08-06
+
+### Changed
 
 * Update FSharp.Analyzers.SDK to `0.26.1`. [#110](https://github.com/ionide/ionide-analyzers/pull/110)
 
-## 0.11.0 - 2024-05-15
+## [0.11.0] - 2024-05-15
 
 ### Changed
 
 * Update FSharp.Analyzers.SDK to `0.26.0`, FSharp.Compiler.Service to `43.8.300`, and FSharp.Core to `8.0.300`. [#93](https://github.com/ionide/ionide-analyzers/pull/93)
 
-## 0.10.0 - 2024-03-29
+## [0.10.0] - 2024-03-29
 
 ### Added
 * HeadConsEmptyListPatternAnalyzer. [#85](https://github.com/ionide/ionide-analyzers/pull/85)
@@ -109,17 +111,17 @@
 * EqualsNullAnalyzer [#85](https://github.com/ionide/ionide-analyzers/pull/85)
 * StructDiscriminatedUnionAnalyzer. [#85](https://github.com/ionide/ionide-analyzers/pull/85)
 
-## 0.9.0 - 2024-02-15
+## [0.9.0] - 2024-02-15
 
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.25.0`. [#68](https://github.com/ionide/ionide-analyzers/pull/75)
 
-## 0.8.0 - 2024-01-30
+## [0.8.0] - 2024-01-30
 
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.24.0`. [#68](https://github.com/ionide/ionide-analyzers/pull/75)
 
-## 0.7.0 - 2024-01-10
+## [0.7.0] - 2024-01-10
 
 ### Added
 * Add fix-support to the CopyAndUpdateRecordChangesAllFieldsAnalyzer. [#68](https://github.com/ionide/ionide-analyzers/pull/68)
@@ -127,40 +129,40 @@
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.23.0`. [#68](https://github.com/ionide/ionide-analyzers/pull/68)
 
-## 0.6.1 - 2024-01-01
+## [0.6.1] - 2024-01-01
 
 ### Added
 * Add editor support to all analyzers. [#64](https://github.com/ionide/ionide-analyzers/pull/64)
 
-## 0.6.0 - 2023-12-20
+## [0.6.0] - 2023-12-20
 
 ### Changed
 * Update FSharp.Analyzers.SDK to `0.22.0`. [#60](https://github.com/ionide/ionide-analyzers/pull/60)
 
-## 0.5.1 - 2023-12-06
+## [0.5.1] - 2023-12-06
 
 ### Fixed
 * Handle types without a FullName more gracefully in the EmptyStringAnalyzer. [#48](https://github.com/ionide/ionide-analyzers/pull/48)
 * Handle types without a FullName more gracefully in the HandleOptionGracefullyAnalyzer. [#50](https://github.com/ionide/ionide-analyzers/pull/50)
 
-## 0.5.0 - 2023-11-23
+## [0.5.0] - 2023-11-23
 
 ### Changed
 * Reworks `ReplaceOptionGetWithGracefulHandlingAnalyzer` to handle ValueOption's and `.Value` member access. [#33](https://github.com/ionide/ionide-analyzers/pull/33) 
 * Reworks `SquareBracketArrayAnalyzer` to handle all generic types that should be postfixed. [#39](https://github.com/ionide/ionide-analyzers/pull/39)
 * Update FSharp.Analyzers.SDK to `0.21.0`. [#45](https://github.com/ionide/ionide-analyzers/pull/45)
 
-## 0.4.0 - 2023-11-15
+## [0.4.0] - 2023-11-15
 
 ### Added
 * ReplaceOptionGetWithGracefulHandlingAnalyzer [#32](https://github.com/ionide/ionide-analyzers/pull/32)
 
-## 0.3.0 - 2023-11-13
+## [0.3.0] - 2023-11-13
 
 ### Changed
 * Update FSharp.Analyzers.SDK to v0.20.0. [#26](https://github.com/ionide/ionide-analyzers/pull/26)
 
-## 0.2.0 - 2023-11-09
+## [0.2.0] - 2023-11-09
 
 ### Fixed
 * Fix analyzers urls. [#19](https://github.com/ionide/ionide-analyzers/pull/19)
@@ -170,12 +172,12 @@
 * Support for referencing a local analyzers SDK. [#18](https://github.com/ionide/ionide-analyzers/pull/18)
 * EmptyStringAnalyzer. [#20](https://github.com/ionide/ionide-analyzers/pull/20)
 
-## 0.1.1 - 2023-11-07
+## [0.1.1] - 2023-11-07
 
 ### Fixed
 * Update NuGet properties. [#14](https://github.com/ionide/ionide-analyzers/pull/14)
 
-## 0.1.0 - 2023-11-07
+## [0.1.0] - 2023-11-07
 
 ### Added
 * Initial version

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="FSharp.Core" Version="[10.1.201]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.12.201]" />
-    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
+    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="FSharp.Core" Version="[10.0.101]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.10.101]" />
-    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
+    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="NUnit" Version="4.3.2" />


### PR DESCRIPTION
This requires adding brackets around the version numbers, but the new version no longer requires lists to use '-' instead of '*' so it's a more minimal change than before.

Superceeds #157