### PR TITLE
feat: bump FSharp.Analyzer.SDK to v0.36.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,22 +3,25 @@
   "isRoot": true,
   "tools": {
     "fsharp-analyzers": {
-      "version": "0.35.0",
+      "version": "0.36.0",
       "commands": [
         "fsharp-analyzers"
-      ]
+      ],
+      "rollForward": false
     },
     "fantomas": {
       "version": "7.0.3",
       "commands": [
         "fantomas"
-      ]
+      ],
+      "rollForward": false
     },
     "fsdocs-tool": {
       "version": "20.0.1",
       "commands": [
         "fsdocs"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.0 - 2026-03-13
+
+### Fixed
+
+* Update FSharp.Analyzers.SDK to `0.36.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.36.0) for details. [#168](https://github.com/ionide/ionide-analyzers/pull/168)
+
 ## 0.14.11 - 2026-01-25
 
 ### Fixed 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.374" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.35.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.35.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.36.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.36.0]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hello,

After updating to `fsharp-analyzers` version `0.36.0` in [Fable](https://github.com/fable-compiler/Fable/pull/4396) repo, we are seeing issues with running the Ionide.Analyzers.

It seems caused by the Ionide.Analyzers not being built againt SDK version 0.36.0.