### PR TITLE
Update SDK to 0.37.2.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsharp-analyzers": {
-      "version": "0.36.0",
+      "version": "0.37.2",
       "commands": [
         "fsharp-analyzers"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.0 - 2026-08-11
+
+### Fixed
+
+* Update FSharp.Analyzers.SDK to `0.37.2`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.37.2) for details. [#180](https://github.com/ionide/ionide-analyzers/pull/180)
+
 ## 0.15.0 - 2026-03-13
 
 ### Fixed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="FSharp.Core" Version="[10.0.101]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.10.101]" />
+    <PackageVersion Include="FSharp.Core" Version="[10.1.201]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.12.201]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -14,7 +14,7 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.374" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.36.0]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.36.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.37.2]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.37.2]" />
   </ItemGroup>
 </Project>

--- a/src/Ionide.Analyzers/LanguageVersionShim.fs
+++ b/src/Ionide.Analyzers/LanguageVersionShim.fs
@@ -63,7 +63,14 @@ type LanguageVersionShim(versionText: string) =
     static let LanguageVersionTy =
         lazy (Type.GetType("FSharp.Compiler.Features+LanguageVersion, FSharp.Compiler.Service"))
 
-    static let ctor = lazy (LanguageVersionTy.Value.GetConstructor([| typeof<string> |]))
+    // The constructor gained additional (optional) parameters over time, so we only match on the version text.
+    static let ctor =
+        lazy
+            (LanguageVersionTy.Value.GetConstructors()
+             |> Array.find (fun c ->
+                 let parameters = c.GetParameters()
+                 parameters.Length >= 1 && parameters[0].ParameterType = typeof<string>
+             ))
 
     static let isPreviewEnabled =
         lazy (ReflectionDelegates.createGetter<bool> LanguageVersionTy.Value "IsPreviewEnabled")
@@ -75,7 +82,12 @@ type LanguageVersionShim(versionText: string) =
                 LanguageFeatureShim.Type
                 "SupportsFeature")
 
-    let realLanguageVersion = ctor.Value.Invoke([| versionText |])
+    let realLanguageVersion =
+        let arguments =
+            ctor.Value.GetParameters()
+            |> Array.mapi (fun idx _ -> if idx = 0 then box versionText else null)
+
+        ctor.Value.Invoke(arguments)
 
     member x.IsPreviewEnabled = isPreviewEnabled.Value realLanguageVersion
 

--- a/src/Ionide.Analyzers/Performance/ReturnStructPartialActivePatternAnalyzer.fs
+++ b/src/Ionide.Analyzers/Performance/ReturnStructPartialActivePatternAnalyzer.fs
@@ -88,7 +88,7 @@ let rec collectSomeAndNoneFromExprBody (expr: SynExpr) (finalContinuation: Ident
 
         sequence continuations finalContinuation
 
-    | SynExpr.LetOrUse(body = expr)
+    | SynExpr.LetOrUse { Body = expr }
     | SynExpr.Paren(expr = expr)
     | SynExpr.Typed(expr = expr) -> collectSomeAndNoneFromExprBody expr finalContinuation
     | _ -> finalContinuation []


### PR DESCRIPTION
This also bumps FSharp.Core and FSharp.Compiler.Service to the appropriate versions that match the SDK.
There are two relevant breaking changes in the compiler service:
- `SynExpr.LetOrUse` no longer exposes named fields, and instead contains a single `SynLetOrUse` record. It's used in the `ReturnStructPartialActivePatternAnalyzer`.
- The `LanguageVersion` constructor gained a parameter, so `LanguageVersionShim` needs to look for a constructor with a string parameter and possibly others (setting the other parameters to `null`).