### PR TITLE
Use NuGet trusted publishing for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         id: login
         uses: NuGet/login@v1
         with:
-          user: chethusk
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Release
         run: dotnet fsi build.fsx -- -p Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,14 @@ jobs:
             9.x
             10.x
 
+      - name: NuGet login
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: chethusk
+
       - name: Release
         run: dotnet fsi build.fsx -- -p Release
         env:
-          NUGET_KEY: ${{ secrets.IONIDE_ANALYZER_NUGET_PUBLISH_KEY }}
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- authenticate the release workflow with `NuGet/login@v1` using the `chethusk` NuGet account
- pass the resulting short-lived API key to the existing release pipeline
- remove the dependency on the long-lived `IONIDE_ANALYZER_NUGET_PUBLISH_KEY` secret

The workflow already grants `id-token: write`, which allows the NuGet login action to complete the OIDC exchange.