### PR TITLE
Add Compose Operators to Mixed Direction Analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.0 - 2026-08-15
+
+### Changed
+
+* Rename MixedPipeDirectionAnalyzer to MixedFlowDirectionAnalyzer and extend it to cover mixed pipe and composition directions.
+
 ## 0.16.0 - 2026-08-11
 
 ### Added

--- a/docs/style/013.md
+++ b/docs/style/013.md
@@ -1,15 +1,15 @@
 ---
-title: MixedPipeDirectionAnalyzer
+title: MixedFlowDirectionAnalyzer
 category: style
 categoryindex: 3
 index: 2
 ---
 
-# MixedPipeDirectionAnalyzer
+# MixedFlowDirectionAnalyzer
 
 ## Problem
 
-The forward pipes (`|>`, `||>`, `|||>`) and the backward pipes (`<|`, `<||`, `<|||`) are left-associative and share a precedence level, so they can be chained together in a single expression.
+The forward pipe (`|>`, `||>`, `|||>`) and composition (`>>`) operators, and their backward counterparts (`<|`, `<||`, `<|||`, `<<`), are left-associative and share a precedence level, so they can be chained together in a single expression.
 When both directions appear in the same chain, the reader has to start in the middle and work outwards two ways at once.
 
 ```fsharp
@@ -25,9 +25,14 @@ let d items =
     |> String.concat ", "
     |> wrap
     <| "!"
+
+let increment n = n + 1
+let asText n = string n
+let length (text: string) = text.Length
+let composed = increment >> asText << length
 ```
 
-Arity does not matter, only direction. Every combination of a forward pipe with a backward pipe is reported:
+Operator family does not matter, only direction. Every combination of a forward pipe or composition operator with a backward pipe or composition operator is reported:
 
 ```fsharp
 // Triggers analyzer
@@ -37,6 +42,10 @@ let f x y z = x |> add3 <|| (y, z)
 
 let add x y = x + y
 let g x y = add <|| (x, y) |> string
+
+let createAdder x = fun y -> x + y
+let parseNumber (text: string) = int text
+let h x = x |> createAdder << parseNumber
 ```
 
 ## Fix
@@ -69,7 +78,7 @@ let boundPipeline items =
     wrap joined "!"
 ```
 
-A chain that runs in one direction is not reported, whatever mix of arities it uses. A backward pipe on its own stays available as the idiomatic way to drop a trailing parenthesis around a multi-line argument:
+A chain that runs in one direction is not reported, including a same-direction mix of pipe and composition operators. A backward pipe on its own stays available as the idiomatic way to drop a trailing parenthesis around a multi-line argument:
 
 ```fsharp
 // Does not trigger analyzer
@@ -77,11 +86,14 @@ let h b = failwith <| sprintf "unexpected: %s" b
 
 let add x y = x + y
 let i x y = (x, y) ||> add |> string
+
+let createAdder x = fun y -> x + y
+let forwardMixed x y = (x |> createAdder >> string) y
 ```
 
 ## Scope
 
-Only operators on the same chain are compared. Parenthesizing an inner pipeline makes it a separate expression. A pipe nested inside a lambda or a parenthesized argument belongs to a different expression and is left alone:
+Only operators on the same chain are compared. Parenthesizing an inner pipeline or composition makes it a separate expression. A flow operator nested inside a lambda or a parenthesized argument belongs to a different expression and is left alone:
 
 ```fsharp
 // Does not trigger analyzer
@@ -92,4 +104,9 @@ let lambdaNestedPipeline items =
 
 let parenthesizedInnerPipeline items =
     ignore <| (items |> List.length)
+
+let increment n = n + 1
+let asText n = string n
+let parenthesizedInnerComposition =
+    ignore <| (increment >> asText)
 ```

--- a/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
+++ b/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
@@ -28,7 +28,7 @@
     <Compile Include="Performance\CombinePipedModuleFunctionsAnalyzer.fs" />
     <Compile Include="Performance\EqualsNullAnalyzer.fs" />
     <Compile Include="Suggestion\StructDiscriminatedUnionAnalyzer.fs" />
-    <Compile Include="Style\MixedPipeDirectionAnalyzer.fs" />
+    <Compile Include="Style\MixedFlowDirectionAnalyzer.fs" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'true'">
     <ProjectReference Include="$(LocalAnalyzersSDKRepo)/src/FSharp.Analyzers.SDK/FSharp.Analyzers.SDK.fsproj" />

--- a/src/Ionide.Analyzers/Style/MixedFlowDirectionAnalyzer.fs
+++ b/src/Ionide.Analyzers/Style/MixedFlowDirectionAnalyzer.fs
@@ -1,4 +1,4 @@
-module Ionide.Analyzers.Style.MixedPipeDirectionAnalyzer
+module Ionide.Analyzers.Style.MixedFlowDirectionAnalyzer
 
 open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
@@ -8,39 +8,39 @@ open Ionide.Analyzers.UntypedOperations
 
 [<Literal>]
 let message =
-    "This pipeline mixes forward pipes (|>, ||>, |||>) with backward pipes (<|, <||, <|||). Use a single direction, or bind an intermediate value with let."
+    "This expression mixes forward flow operators (|>, ||>, |||>, >>) with backward flow operators (<|, <||, <|||, <<). Use a single direction, or bind an intermediate value with let."
 
-type private PipeDirection =
+type private FlowDirection =
     | Forward
     | Backward
 
-let private forwardPipes = set [ "|>"; "||>"; "|||>" ]
-let private backwardPipes = set [ "<|"; "<||"; "<|||" ]
+let private forwardFlowOperators = set [ "|>"; "||>"; "|||>"; ">>" ]
+let private backwardFlowOperators = set [ "<|"; "<||"; "<|||"; "<<" ]
 
 [<return: Struct>]
-let private (|PipeNotation|_|) (originalNotation: string) =
-    if forwardPipes.Contains originalNotation then
+let private (|FlowNotation|_|) (originalNotation: string) =
+    if forwardFlowOperators.Contains originalNotation then
         ValueSome Forward
-    elif backwardPipes.Contains originalNotation then
+    elif backwardFlowOperators.Contains originalNotation then
         ValueSome Backward
     else
         ValueNone
 
-/// A single link of a pipe chain, such as `lhs |> rhs` or `lhs <|| rhs`.
+/// A single link of a flow-operator chain, such as `lhs |> rhs` or `lhs << rhs`.
 /// Yields the direction, the operator identifier and the left-hand side.
 [<return: Struct>]
-let private (|PipeApp|_|) (e: SynExpr) =
+let private (|FlowOperatorApp|_|) (e: SynExpr) =
     match e with
-    | SynExpr.App(funcExpr = AnyInfixOperator(PipeNotation direction, operatorIdent, lhs)) ->
+    | SynExpr.App(funcExpr = AnyInfixOperator(FlowNotation direction, operatorIdent, lhs)) ->
         ValueSome(direction, operatorIdent, lhs)
     | _ -> ValueNone
 
-/// The pipe operators are left-associative, so a chain of them is a left spine.
+/// Flow operators are left-associative, so a chain of them is a left spine.
 /// Collect every operator on that spine, in source order.
 let private collectChainOperators (e: SynExpr) =
     let rec loop e acc =
         match e with
-        | PipeApp(direction, operatorIdent, lhs) -> loop lhs ((direction, operatorIdent.idRange) :: acc)
+        | FlowOperatorApp(direction, operatorIdent, lhs) -> loop lhs ((direction, operatorIdent.idRange) :: acc)
         | _ -> acc
 
     loop e []
@@ -49,7 +49,7 @@ let private collectChainOperators (e: SynExpr) =
 /// Inner links are skipped so a mixed chain reports once, at its outermost node.
 let private isChainRoot (path: SyntaxNode list) =
     match path with
-    | SyntaxNode.SynExpr(AnyInfixOperator(PipeNotation _, _, _)) :: _ -> false
+    | SyntaxNode.SynExpr(AnyInfixOperator(FlowNotation _, _, _)) :: _ -> false
     | _ -> true
 
 let private analyze (parsedInput: ParsedInput) : Message list =
@@ -59,7 +59,7 @@ let private analyze (parsedInput: ParsedInput) : Message list =
         { new SyntaxCollectorBase() with
             override _.WalkExpr(path, synExpr) =
                 match synExpr with
-                | PipeApp _ when isChainRoot path ->
+                | FlowOperatorApp _ when isChainRoot path ->
                     let operators = collectChainOperators synExpr
                     let hasForward = operators |> List.exists (fun (d, _) -> d = Forward)
                     let hasBackward = operators |> List.exists (fun (d, _) -> d = Backward)
@@ -76,7 +76,7 @@ let private analyze (parsedInput: ParsedInput) : Message list =
     ranges
     |> Seq.map (fun range ->
         {
-            Type = "mixedPipeDirection"
+            Type = "mixedFlowDirection"
             Message = message
             Code = "IONIDE-013"
             Severity = Severity.Info
@@ -87,19 +87,19 @@ let private analyze (parsedInput: ParsedInput) : Message list =
     |> Seq.toList
 
 [<Literal>]
-let name = "MixedPipeDirectionAnalyzer"
+let name = "MixedFlowDirectionAnalyzer"
 
 [<Literal>]
 let shortDescription =
-    "Detect expressions that mix the forward and backward pipe operators."
+    "Detect expressions that mix forward and backward pipe or composition operators."
 
 [<Literal>]
 let helpUri = "https://ionide.io/ionide-analyzers/style/013.html"
 
 [<CliAnalyzer(name, shortDescription, helpUri)>]
-let mixedPipeDirectionCliAnalyzer: Analyzer<CliContext> =
+let mixedFlowDirectionCliAnalyzer: Analyzer<CliContext> =
     fun (context: CliContext) -> async { return analyze context.ParseFileResults.ParseTree }
 
 [<EditorAnalyzer(name, shortDescription, helpUri)>]
-let mixedPipeDirectionEditorAnalyzer: Analyzer<EditorContext> =
+let mixedFlowDirectionEditorAnalyzer: Analyzer<EditorContext> =
     fun (context: EditorContext) -> async { return analyze context.ParseFileResults.ParseTree }

--- a/tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj
+++ b/tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj
@@ -19,7 +19,7 @@
     <Compile Include="Performance\CombinePipedModuleFunctionsAnalyzerTests.fs" />
     <Compile Include="Performance\EqualsNullAnalyzerTests.fs" />
     <Compile Include="Suggestion\StructDiscriminatedUnionAnalyzerTests.fs" />
-    <Compile Include="Style\MixedPipeDirectionAnalyzerTests.fs" />
+    <Compile Include="Style\MixedFlowDirectionAnalyzerTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Ionide.Analyzers.Tests/Style/MixedFlowDirectionAnalyzerTests.fs
+++ b/tests/Ionide.Analyzers.Tests/Style/MixedFlowDirectionAnalyzerTests.fs
@@ -1,9 +1,9 @@
-module Ionide.Analyzers.Tests.Style.MixedPipeDirectionAnalyzerTests
+module Ionide.Analyzers.Tests.Style.MixedFlowDirectionAnalyzerTests
 
 open NUnit.Framework
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Analyzers.SDK.Testing
-open Ionide.Analyzers.Style.MixedPipeDirectionAnalyzer
+open Ionide.Analyzers.Style.MixedFlowDirectionAnalyzer
 
 let mutable projectOptions: FSharpProjectOptions = FSharpProjectOptions.zero
 
@@ -26,7 +26,7 @@ let a b c = b |> add <| c
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Not.Empty)
         Assert.That(Assert.messageContains message msgs.[0], Is.True)
     }
@@ -42,7 +42,7 @@ let a b = string <| b |> ignore
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Not.Empty)
         Assert.That(Assert.messageContains message msgs.[0], Is.True)
     }
@@ -66,7 +66,7 @@ let a (items: int list) =
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Not.Empty)
         Assert.That(Assert.messageContains message msgs.[0], Is.True)
     }
@@ -83,7 +83,7 @@ let a b c d = b |> add <| c |> add <| d
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
     }
 
@@ -99,7 +99,7 @@ let a b c = b |> add <| c
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Not.Empty)
         let range = msgs.[0].Range
         Assert.That(range.StartLine, Is.EqualTo 5)
@@ -121,7 +121,7 @@ let d e f = e |> add <| f
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(2).Items)
     }
 
@@ -137,7 +137,7 @@ let a x y z = (x, y) ||> f3 <| z
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
         Assert.That(Assert.messageContains message msgs.[0], Is.True)
     }
@@ -154,7 +154,7 @@ let a x y z w = (x, y, z) |||> f4 <| w
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
     }
 
@@ -170,7 +170,7 @@ let a x y z = x |> f3 <|| (y, z)
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
     }
 
@@ -186,7 +186,7 @@ let a x y z w = x |> f4 <||| (y, z, w)
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
     }
 
@@ -202,7 +202,7 @@ let a x y = f2 <|| (x, y) |> string
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
     }
 
@@ -219,7 +219,7 @@ let a x = mkPair <| x ||> f2
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
     }
 
@@ -236,8 +236,135 @@ let a x = mkTriple <| x |||> f3
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Has.Exactly(1).Items)
+    }
+
+[<Test>]
+let ``forward then backward composition should produce diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText n = string n
+let length (text: string) = text.Length
+let a = increment >> asText << length
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+        Assert.That(Assert.messageContains message msgs.[0], Is.True)
+    }
+
+[<Test>]
+let ``backward then forward composition should produce diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText n = string n
+let length (text: string) = text.Length
+let a = increment << length >> asText
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+    }
+
+[<Test>]
+let ``forward pipe then backward composition should produce diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let createAdder (x: int) = fun y -> x + y
+let parseNumber (text: string) = int text
+let a x = x |> createAdder << parseNumber
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+    }
+
+[<Test>]
+let ``backward pipe then forward composition should produce diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let createAdder (x: int) = fun y -> x + y
+let a x = createAdder <| x >> string
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+    }
+
+[<Test>]
+let ``forward composition then backward pipe should produce diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText n = string n
+let a = increment >> asText <| 1
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+    }
+
+[<Test>]
+let ``backward composition then forward pipe should produce diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let length (text: string) = text.Length
+let a = increment << length |> ignore
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+    }
+
+[<Test>]
+let ``a long mixed flow chain should report once across its full operator span`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText n = string n
+let length (text: string) = text.Length
+let a = increment >> asText << length >> asText
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Has.Exactly(1).Items)
+        let range = msgs.[0].Range
+        Assert.That(range.StartLine, Is.EqualTo 7)
+        Assert.That(range.StartColumn, Is.EqualTo 18)
+        Assert.That(range.EndLine, Is.EqualTo 7)
+        Assert.That(range.EndColumn, Is.EqualTo 40)
     }
 
 [<Test>]
@@ -252,7 +379,75 @@ let a x y = (x, y) ||> f2 |> string
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+[<Test>]
+let ``forward pipe and forward composition should not trigger diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let createAdder (x: int) = fun y -> x + y
+let a x = x |> createAdder >> string
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+[<Test>]
+let ``backward composition and backward pipe should not trigger diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let createAdder (x: int) = fun y -> x + y
+let parseNumber (text: string) = int text
+let a x = createAdder << parseNumber <| x
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+[<Test>]
+let ``forward composition operators should not trigger diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText n = string n
+let a = increment >> asText >> id
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+[<Test>]
+let ``backward composition operators should not trigger diagnostic`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText (n: int) = string n
+let length (text: string) = text.Length
+let a = increment << length << asText
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }
 
@@ -268,7 +463,7 @@ let a x y z = f3 <|| (x, y) <| z
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }
 
@@ -287,7 +482,7 @@ let a b =
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }
 
@@ -302,7 +497,7 @@ let a b = failwith <| sprintf "unexpected: %s" b
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }
 
@@ -319,7 +514,7 @@ let a b =
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }
 
@@ -337,7 +532,7 @@ let a b =
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }
 
@@ -352,6 +547,23 @@ let a b = ignore <| (b |> List.length)
     """
 
         let ctx = getContext projectOptions source
-        let! msgs = mixedPipeDirectionCliAnalyzer ctx
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+[<Test>]
+let ``a parenthesized inner composition is its own expression`` () =
+    async {
+        let source =
+            """
+module M
+
+let increment (n: int) = n + 1
+let asText n = string n
+let a = ignore <| (increment >> asText)
+    """
+
+        let ctx = getContext projectOptions source
+        let! msgs = mixedFlowDirectionCliAnalyzer ctx
         Assert.That(msgs, Is.Empty)
     }


### PR DESCRIPTION
This pull request renames and extends the analyzer that detects mixed usage of forward and backward flow operators in F#. The analyzer now covers both pipe and composition operators, updates all relevant documentation and tests, and improves clarity in its messaging and code.

Question: This shouldn't be a breaking change since the analyzer code remains the same right? Or do we consider that surface breaking? I can always revert the renaming to prevent this