### PR TITLE
Update analyzers tooling to 0.38.0 and retarget to .NET 10.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsharp-analyzers": {
-      "version": "0.37.2",
+      "version": "0.38.0",
       "commands": [
         "fsharp-analyzers"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Analyzers
         continue-on-error: true
-        run: dotnet fsharp-analyzers --project ./src/Ionide.Analyzers/Ionide.Analyzers.fsproj --project ./tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj --analyzers-path ./src/Ionide.Analyzers/bin/Release/net8.0 --report ./report.sarif
+        run: dotnet fsharp-analyzers --project ./src/Ionide.Analyzers/Ionide.Analyzers.fsproj --project ./tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj --analyzers-path ./src/Ionide.Analyzers/bin/Release/net10.0 --report ./report.sarif
         if: matrix.os == 'ubuntu-latest'
 
       - name: Upload SARIF file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+* *Breaking*: [All packages now target .NET 10](https://github.com/ionide/ionide-analyzers/pull/193)
+* Update FSharp.Analyzers.SDK to `0.38.0`. Checkout the [release notes](https://github.com/ionide/FSharp.Analyzers.SDK/releases/tag/v0.38.0) for details. [#180](https://github.com/ionide/ionide-analyzers/pull/193)
+
 ## [0.17.0] - 2026-08-15
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="FSharp.Core" Version="[10.1.201]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.12.201]" />
+    <PackageVersion Include="FSharp.Core" Version="[10.1.400]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.12.400]" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
@@ -14,7 +14,7 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.374" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalAnalyzersSDK)' == 'false'">
-    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.37.2]" />
-    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.37.2]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK" Version="[0.38.0]" />
+    <PackageVersion Include="FSharp.Analyzers.SDK.Testing" Version="[0.38.0]" />
   </ItemGroup>
 </Project>

--- a/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
+++ b/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Tailcalls>true</Tailcalls>

--- a/src/Ionide.Analyzers/Performance/ReturnStructPartialActivePatternAnalyzer.fs
+++ b/src/Ionide.Analyzers/Performance/ReturnStructPartialActivePatternAnalyzer.fs
@@ -147,7 +147,7 @@ let analyze (sourceText: ISourceText) (parsedInput: ParsedInput) (checkResults: 
             if
                 not mfv.IsActivePattern
                 || mfv.ReturnParameter.Type.IsFunctionType
-                || mfv.ReturnParameter.Type.BasicQualifiedName = "Microsoft.FSharp.Core.voption`1"
+                || mfv.ReturnParameter.Type.BasicQualifiedName = Some "Microsoft.FSharp.Core.voption`1"
             then
                 None
             else

--- a/src/Ionide.Analyzers/Suggestion/StructDiscriminatedUnionAnalyzer.fs
+++ b/src/Ionide.Analyzers/Suggestion/StructDiscriminatedUnionAnalyzer.fs
@@ -117,7 +117,9 @@ let private analyze
                         false
                     else
 
-                    primitives.Contains ff.FieldType.BasicQualifiedName
+                    match ff.FieldType.BasicQualifiedName with
+                    | Some name -> primitives.Contains name
+                    | _ -> false
                 )
 
             if not allTypesArePrimitive then

--- a/tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj
+++ b/tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
Updates to the latest SDK, which now targets .NET 10.0.

Also refs https://github.com/ionide/ionide-analyzers/issues/184