### PR TITLE
Update NuGet.Protocol to 7.9.0 in build.fsx

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,6 +1,6 @@
 #r "nuget: Fun.Build, 1.0.3"
 #r "nuget: Fake.IO.FileSystem, 6.0.0"
-#r "nuget: NuGet.Protocol, 6.7.0"
+#r "nuget: NuGet.Protocol, 7.9.0"
 #r "nuget: Ionide.KeepAChangelog, 0.1.8"
 #r "nuget: Humanizer.Core, 2.14.1"
 


### PR DESCRIPTION
There are build warnings about the existing version having 'critical severity vulnerabilities'

ref

<img width="1896" height="127" alt="image" src="https://github.com/user-attachments/assets/c65094f7-8a4a-47ac-8820-9939e11d6506" />
