### PR TITLE
Remove .NET8/9 from the setup-dotnet CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
         with:  
           global-json-file: 'global.json'
           dotnet-version: |
-            8.x 
-            9.x
             10.x
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
         with:  
           global-json-file: 'global.json'
           dotnet-version: |
-            8.x 
-            9.x
             10.x
 
       - name: NuGet login


### PR DESCRIPTION
Are these needed any more, now everything is built as .NET 10?