### PR TITLE
Create NoArgFormatStringAnalyzer

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "fsdocs-tool": {
-      "version": "22.2.0",
+      "version": "23.0.0-alpha.1",
       "commands": [
         "fsdocs"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+* Create NoArgFormatStringAnalyzer, reports printf-style functions applied to a format string without format specifiers.
+
 ## [0.18.0] - 2026-09-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-* Create NoArgFormatStringAnalyzer, reports printf-style functions applied to a format string without format specifiers.
+* Create NoArgFormatStringAnalyzer, reports printf-style functions (including `fprintf`, `fprintfn` and `bprintf`) applied to a format string without format specifiers.
 
 ## [0.18.0] - 2026-09-08
 

--- a/build.fsx
+++ b/build.fsx
@@ -1,4 +1,6 @@
-#r "nuget: Fun.Build, 1.0.3"
+#!/usr/bin/env -S dotnet fsi --
+
+#r "nuget: Fun.Build, 1.1.18"
 #r "nuget: Fake.IO.FileSystem, 6.0.0"
 #r "nuget: NuGet.Protocol, 7.9.0"
 #r "nuget: Ionide.KeepAChangelog, 0.1.8"
@@ -70,7 +72,15 @@ pipeline "Docs" {
                 "DOTNET_ROLL_FORWARD", "LatestMajor"
             |]
         run "dotnet tool restore"
-        run "dotnet fsdocs watch --port 7890"
+        run (fun ctx ->
+            let extraArgs =
+                fsi.CommandLineArgs
+                |> Array.skipWhile (fun arg -> arg <> "Docs")
+                |> Array.skip 1
+                |> String.concat " "
+
+            ctx.RunCommand $"dotnet fsdocs watch --port 7890 %s{extraArgs}"
+        )
     }
     runIfOnlySpecified true
 }

--- a/docs/performance/014.md
+++ b/docs/performance/014.md
@@ -1,0 +1,42 @@
+---
+title: NoArgFormatStringAnalyzer
+category: performance
+categoryindex: 4
+index: 5
+---
+
+# NoArgFormatStringAnalyzer
+
+Applying a printf-style function (`sprintf`, `failwithf`, `printf`, `printfn`, `eprintf`, `eprintfn`) to a format string that has no format specifiers still goes through the F# format parsing machinery on every call.
+When the string is a constant, the same result can be obtained with the plain string literal.
+
+## Problem
+
+```fsharp
+// Analyzer will trigger
+let header = sprintf "<pre><code>"
+let fail () = failwithf "boom"
+printfn "hello"
+```
+
+## Fix
+
+```fsharp
+let header = "<pre><code>"
+let fail () = failwith "boom"
+stdout.WriteLine "hello"
+```
+
+An escaped percent sign (`%%`) is not a format specifier, so `sprintf "100%%"` is also reported and the fix unescapes it to `"100%"`.
+
+Format strings with at least one specifier, interpolated strings and non-constant format values are not reported:
+
+```fsharp
+// Does not trigger analyzer
+let langCode = sprintf "language-%s" "fsharp"
+let greet name = sprintf $"hello %s{name}"
+```
+
+## Code fix
+
+This analyzer has a code fix for Ionide.

--- a/docs/performance/014.md
+++ b/docs/performance/014.md
@@ -7,7 +7,7 @@ index: 5
 
 # NoArgFormatStringAnalyzer
 
-Applying a printf-style function (`sprintf`, `failwithf`, `printf`, `printfn`, `eprintf`, `eprintfn`) to a format string that has no format specifiers still goes through the F# format parsing machinery on every call.
+Applying a printf-style function (`sprintf`, `failwithf`, `printf`, `printfn`, `eprintf`, `eprintfn`, `fprintf`, `fprintfn`, `bprintf`) to a format string that has no format specifiers still goes through the F# format parsing machinery on every call.
 When the string is a constant, the same result can be obtained with the plain string literal.
 
 ## Problem
@@ -17,6 +17,8 @@ When the string is a constant, the same result can be obtained with the plain st
 let header = sprintf "<pre><code>"
 let fail () = failwithf "boom"
 printfn "hello"
+fprintfn tw "hello"
+Printf.bprintf sb "hello"
 ```
 
 ## Fix
@@ -25,6 +27,8 @@ printfn "hello"
 let header = "<pre><code>"
 let fail () = failwith "boom"
 stdout.WriteLine "hello"
+tw.WriteLine "hello"
+sb.Append "hello" |> ignore
 ```
 
 An escaped percent sign (`%%`) is not a format specifier, so `sprintf "100%%"` is also reported and the fix unescapes it to `"100%"`.

--- a/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
+++ b/src/Ionide.Analyzers/Ionide.Analyzers.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Performance\ReturnStructPartialActivePatternAnalyzer.fs" />
     <Compile Include="Performance\CombinePipedModuleFunctionsAnalyzer.fs" />
     <Compile Include="Performance\EqualsNullAnalyzer.fs" />
+    <Compile Include="Performance\NoArgFormatStringAnalyzer.fs" />
     <Compile Include="Suggestion\StructDiscriminatedUnionAnalyzer.fs" />
     <Compile Include="Style\MixedFlowDirectionAnalyzer.fs" />
   </ItemGroup>

--- a/src/Ionide.Analyzers/Performance/NoArgFormatStringAnalyzer.fs
+++ b/src/Ionide.Analyzers/Performance/NoArgFormatStringAnalyzer.fs
@@ -1,0 +1,133 @@
+module Ionide.Analyzers.Performance.NoArgFormatStringAnalyzer
+
+open System.Collections.Generic
+open FSharp.Compiler.Text
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Analyzers.SDK
+open FSharp.Analyzers.SDK.ASTCollecting
+open Ionide.Analyzers.TypedOperations
+
+[<Literal>]
+let message =
+    "Format string has no format specifiers, the printf-style function adds parsing overhead for nothing."
+
+/// Maps the printf-style function to the non-format alternative. `None` means the argument itself is the fix.
+let private replacements =
+    Map.ofList
+        [
+            "sprintf", None
+            "failwithf", Some "failwith"
+            "printf", Some "stdout.Write"
+            "printfn", Some "stdout.WriteLine"
+            "eprintf", Some "stderr.Write"
+            "eprintfn", Some "stderr.WriteLine"
+        ]
+
+[<Struct>]
+type private FormatCall = | FormatCall of functionIdent: Ident * formatText: string * formatRange: range * range: range
+
+[<return: Struct>]
+let rec private (|ConstString|_|) =
+    function
+    | SynExpr.Paren(expr = ConstString(text, m)) -> ValueSome(text, m)
+    | SynExpr.Const(SynConst.String(text,
+                                    (SynStringKind.Regular | SynStringKind.Verbatim | SynStringKind.TripleQuote),
+                                    _),
+                    m) -> ValueSome(text, m)
+    | _ -> ValueNone
+
+[<return: Struct>]
+let private (|PrintfFunction|_|) =
+    function
+    | SynExpr.Ident ident -> ValueSome ident
+    | SynExpr.LongIdent(longDotId = SynLongIdent(id = ids)) ->
+        match List.tryLast ids with
+        | None -> ValueNone
+        | Some ident -> ValueSome ident
+    | _ -> ValueNone
+
+/// True when the format string only contains literal text. `%%` is an escaped percent sign and does not count.
+let private hasNoFormatSpecifiers (text: string) =
+    not (text.Replace("%%", "").Contains '%')
+
+let private analyze
+    (sourceText: ISourceText)
+    (parsedInput: ParsedInput)
+    (checkResults: FSharpCheckFileResults)
+    : Message list
+    =
+    let calls = HashSet<FormatCall>()
+
+    let collector =
+        { new SyntaxCollectorBase() with
+            override x.WalkExpr(path, synExpr) =
+                match synExpr with
+                | SynExpr.App(ExprAtomicFlag.NonAtomic, false, PrintfFunction ident, ConstString(text, mFormat), m) when
+                    replacements.ContainsKey ident.idText && hasNoFormatSpecifiers text
+                    ->
+                    calls.Add(FormatCall(ident, text, mFormat, m)) |> ignore
+                | _ -> ()
+        }
+
+    walkAst collector parsedInput
+
+    calls
+    |> Seq.choose (fun (FormatCall(ident, _, mFormat, m)) ->
+        tryFSharpMemberOrFunctionOrValueFromIdent sourceText checkResults ident
+        |> Option.bind (fun mfv ->
+            if mfv.Assembly.SimpleName <> "FSharp.Core" || not mfv.IsFunction then
+                None
+            else
+
+            let literal = (sourceText.GetSubTextFromRange mFormat).Replace("%%", "%")
+
+            let toText =
+                match replacements[ident.idText] with
+                | None -> literal
+                | Some replacement -> $"%s{replacement} %s{literal}"
+
+            Some
+                {
+                    Type = "noArgFormatString"
+                    Message = message
+                    Code = "IONIDE-014"
+                    Severity = Severity.Hint
+                    Range = m
+                    Fixes =
+                        [
+                            {
+                                FromText = ""
+                                FromRange = m
+                                ToText = toText
+                            }
+                        ]
+                }
+        )
+    )
+    |> Seq.toList
+
+[<Literal>]
+let name = "NoArgFormatStringAnalyzer"
+
+[<Literal>]
+let shortDescription =
+    "Detects printf-style functions applied to a format string without format specifiers."
+
+[<Literal>]
+let helpUri = "https://ionide.io/ionide-analyzers/performance/014.html"
+
+[<CliAnalyzer(name, shortDescription, helpUri)>]
+let noArgFormatStringCliAnalyzer: Analyzer<CliContext> =
+    fun (context: CliContext) ->
+        async { return analyze context.SourceText context.ParseFileResults.ParseTree context.CheckFileResults }
+
+[<EditorAnalyzer(name, shortDescription, helpUri)>]
+let noArgFormatStringEditorAnalyzer: Analyzer<EditorContext> =
+    fun (context: EditorContext) ->
+        async {
+            match context.CheckFileResults with
+            | None -> return []
+            | Some checkFileResults ->
+                return analyze context.SourceText context.ParseFileResults.ParseTree checkFileResults
+        }

--- a/src/Ionide.Analyzers/Performance/NoArgFormatStringAnalyzer.fs
+++ b/src/Ionide.Analyzers/Performance/NoArgFormatStringAnalyzer.fs
@@ -12,20 +12,32 @@ open Ionide.Analyzers.TypedOperations
 let message =
     "Format string has no format specifiers, the printf-style function adds parsing overhead for nothing."
 
-/// Maps the printf-style function to the non-format alternative. `None` means the argument itself is the fix.
+type private Replacement =
+    /// The string literal itself is the fix.
+    | Literal
+    /// A function that takes the string literal.
+    | Function of name: string
+    /// A method on the first argument (writer or builder), followed by an optional suffix.
+    | Method of name: string * suffix: string
+
+/// Maps the printf-style function to the non-format alternative.
 let private replacements =
     Map.ofList
         [
-            "sprintf", None
-            "failwithf", Some "failwith"
-            "printf", Some "stdout.Write"
-            "printfn", Some "stdout.WriteLine"
-            "eprintf", Some "stderr.Write"
-            "eprintfn", Some "stderr.WriteLine"
+            "sprintf", Literal
+            "failwithf", Function "failwith"
+            "printf", Function "stdout.Write"
+            "printfn", Function "stdout.WriteLine"
+            "eprintf", Function "stderr.Write"
+            "eprintfn", Function "stderr.WriteLine"
+            "fprintf", Method("Write", "")
+            "fprintfn", Method("WriteLine", "")
+            "bprintf", Method("Append", " |> ignore")
         ]
 
 [<Struct>]
-type private FormatCall = | FormatCall of functionIdent: Ident * formatText: string * formatRange: range * range: range
+type private FormatCall =
+    | FormatCall of functionIdent: Ident * receiver: SynExpr option * formatRange: range * range: range
 
 [<return: Struct>]
 let rec private (|ConstString|_|) =
@@ -64,16 +76,26 @@ let private analyze
             override x.WalkExpr(path, synExpr) =
                 match synExpr with
                 | SynExpr.App(ExprAtomicFlag.NonAtomic, false, PrintfFunction ident, ConstString(text, mFormat), m) when
-                    replacements.ContainsKey ident.idText && hasNoFormatSpecifiers text
+                    hasNoFormatSpecifiers text
                     ->
-                    calls.Add(FormatCall(ident, text, mFormat, m)) |> ignore
+                    match Map.tryFind ident.idText replacements with
+                    | Some(Literal | Function _) -> calls.Add(FormatCall(ident, None, mFormat, m)) |> ignore
+                    | _ -> ()
+                | SynExpr.App(ExprAtomicFlag.NonAtomic,
+                              false,
+                              SynExpr.App(ExprAtomicFlag.NonAtomic, false, PrintfFunction ident, receiver, _),
+                              ConstString(text, mFormat),
+                              m) when hasNoFormatSpecifiers text ->
+                    match Map.tryFind ident.idText replacements with
+                    | Some(Method _) -> calls.Add(FormatCall(ident, Some receiver, mFormat, m)) |> ignore
+                    | _ -> ()
                 | _ -> ()
         }
 
     walkAst collector parsedInput
 
     calls
-    |> Seq.choose (fun (FormatCall(ident, _, mFormat, m)) ->
+    |> Seq.choose (fun (FormatCall(ident, receiver, mFormat, m)) ->
         tryFSharpMemberOrFunctionOrValueFromIdent sourceText checkResults ident
         |> Option.bind (fun mfv ->
             if mfv.Assembly.SimpleName <> "FSharp.Core" || not mfv.IsFunction then
@@ -83,9 +105,21 @@ let private analyze
             let literal = (sourceText.GetSubTextFromRange mFormat).Replace("%%", "%")
 
             let toText =
-                match replacements[ident.idText] with
-                | None -> literal
-                | Some replacement -> $"%s{replacement} %s{literal}"
+                match replacements[ident.idText], receiver with
+                | Literal, _ -> literal
+                | Function name, _ -> $"%s{name} %s{literal}"
+                | Method(name, suffix), Some receiver ->
+                    let receiverText = sourceText.GetSubTextFromRange receiver.Range
+
+                    let receiverText =
+                        match receiver with
+                        | SynExpr.Ident _
+                        | SynExpr.LongIdent _
+                        | SynExpr.Paren _ -> receiverText
+                        | _ -> $"(%s{receiverText})"
+
+                    $"%s{receiverText}.%s{name} %s{literal}%s{suffix}"
+                | Method _, None -> literal
 
             Some
                 {

--- a/tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj
+++ b/tests/Ionide.Analyzers.Tests/Ionide.Analyzers.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Performance\ReturnStructPartialActivePatternAnalyzerTests.fs" />
     <Compile Include="Performance\CombinePipedModuleFunctionsAnalyzerTests.fs" />
     <Compile Include="Performance\EqualsNullAnalyzerTests.fs" />
+    <Compile Include="Performance\NoArgFormatStringAnalyzerTests.fs" />
     <Compile Include="Suggestion\StructDiscriminatedUnionAnalyzerTests.fs" />
     <Compile Include="Style\MixedFlowDirectionAnalyzerTests.fs" />
     <Compile Include="Program.fs" />

--- a/tests/Ionide.Analyzers.Tests/Performance/NoArgFormatStringAnalyzerTests.fs
+++ b/tests/Ionide.Analyzers.Tests/Performance/NoArgFormatStringAnalyzerTests.fs
@@ -31,6 +31,31 @@ let private assertNoMessages (source: string) =
         Assert.That(msgs, Is.Empty)
     }
 
+/// Runs the analyzer on `source`, expects exactly one message with one fix, and returns the source with that fix applied.
+let private codeFixFor (source: string) : Async<string> =
+    async {
+        let ctx = getContext projectOptions source
+        let! msgs = noArgFormatStringCliAnalyzer ctx
+        Assert.That(msgs, Has.Length.EqualTo 1)
+        let fix = msgs[0].Fixes[0]
+        let lines = source.Split '\n'
+
+        let offset line column =
+            (lines |> Array.take (line - 1) |> Array.sumBy (fun l -> l.Length + 1)) + column
+
+        let start = offset fix.FromRange.StartLine fix.FromRange.StartColumn
+        let finish = offset fix.FromRange.EndLine fix.FromRange.EndColumn
+        return source.Substring(0, start) + fix.ToText + source.Substring finish
+    }
+
+/// Asserts the fixed source equals `expected`, and that `expected` compiles without triggering the analyzer again.
+let private becomes (expected: string) (fixedSource: Async<string>) =
+    async {
+        let! fixedSource = fixedSource
+        Assert.That(fixedSource, Is.EqualTo expected)
+        do! assertNoMessages expected
+    }
+
 [<Test>]
 let ``sprintf with plain string`` () =
     assertSingleFix
@@ -117,6 +142,134 @@ let ``eprintf becomes stderr.Write`` () =
         "stderr.Write \"hello\""
         """module Lib
 eprintf "hello"
+"""
+
+[<Test>]
+let ``fprintf becomes Write on the writer`` () =
+    assertSingleFix
+        "tw.Write \"hello\""
+        """module Lib
+let tw = System.IO.TextWriter.Null
+fprintf tw "hello"
+"""
+
+[<Test>]
+let ``fprintfn becomes WriteLine on the writer`` () =
+    assertSingleFix
+        "tw.WriteLine \"hello\""
+        """module Lib
+let tw = System.IO.TextWriter.Null
+fprintfn tw "hello"
+"""
+
+[<Test>]
+let ``bprintf becomes Append on the builder`` () =
+    assertSingleFix
+        "sb.Append \"hello\" |> ignore"
+        """module Lib
+let sb = System.Text.StringBuilder()
+Printf.bprintf sb "hello"
+"""
+
+[<Test>]
+let ``qualified bprintf with long ident receiver`` () =
+    assertSingleFix
+        "state.Builder.Append \"hello\" |> ignore"
+        """module Lib
+type State = { Builder: System.Text.StringBuilder }
+let state = { Builder = System.Text.StringBuilder() }
+Printf.bprintf state.Builder "hello"
+"""
+
+[<Test>]
+let ``bprintf with complex receiver is wrapped in parentheses`` () =
+    assertSingleFix
+        "(mk ()).Append \"hello\" |> ignore"
+        """module Lib
+open Printf
+let mk () = System.Text.StringBuilder()
+bprintf (mk ()) "hello"
+"""
+
+[<Test>]
+let ``fprintf before and after`` () =
+    codeFixFor
+        """module Lib
+
+let write (tw: System.IO.TextWriter) =
+    fprintf tw "hello"
+    fprintf tw "%s" "world"
+"""
+    |> becomes
+        """module Lib
+
+let write (tw: System.IO.TextWriter) =
+    tw.Write "hello"
+    fprintf tw "%s" "world"
+"""
+
+[<Test>]
+let ``fprintfn before and after`` () =
+    codeFixFor
+        """module Lib
+
+let write (tw: System.IO.TextWriter) =
+    fprintfn tw "hello"
+    fprintfn tw "%s" "world"
+"""
+    |> becomes
+        """module Lib
+
+let write (tw: System.IO.TextWriter) =
+    tw.WriteLine "hello"
+    fprintfn tw "%s" "world"
+"""
+
+[<Test>]
+let ``bprintf before and after`` () =
+    codeFixFor
+        """module Lib
+
+let build (sb: System.Text.StringBuilder) =
+    Printf.bprintf sb "hello"
+    Printf.bprintf sb "%s" "world"
+"""
+    |> becomes
+        """module Lib
+
+let build (sb: System.Text.StringBuilder) =
+    sb.Append "hello" |> ignore
+    Printf.bprintf sb "%s" "world"
+"""
+
+[<Test>]
+let ``bprintf as last expression before and after`` () =
+    codeFixFor
+        """module Lib
+
+let build (sb: System.Text.StringBuilder) : unit = Printf.bprintf sb "hello"
+"""
+    |> becomes
+        """module Lib
+
+let build (sb: System.Text.StringBuilder) : unit = sb.Append "hello" |> ignore
+"""
+
+[<Test>]
+let ``fprintf with format specifier does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let tw = System.IO.TextWriter.Null
+fprintf tw "hello %s" "world"
+"""
+
+[<Test>]
+let ``user defined bprintf does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let bprintf (sb: System.Text.StringBuilder) (s: string) = ()
+let sb = System.Text.StringBuilder()
+bprintf sb "hello"
 """
 
 [<Test>]

--- a/tests/Ionide.Analyzers.Tests/Performance/NoArgFormatStringAnalyzerTests.fs
+++ b/tests/Ionide.Analyzers.Tests/Performance/NoArgFormatStringAnalyzerTests.fs
@@ -1,0 +1,166 @@
+module Ionide.Analyzers.Tests.Performance.NoArgFormatStringAnalyzerTests
+
+open NUnit.Framework
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Analyzers.SDK.Testing
+open Ionide.Analyzers.Performance.NoArgFormatStringAnalyzer
+
+let mutable projectOptions: FSharpProjectOptions = FSharpProjectOptions.zero
+
+[<SetUp>]
+let Setup () =
+    task {
+        let! opts = mkOptionsFromProject "net8.0" []
+        projectOptions <- opts
+    }
+
+let private assertSingleFix (expectedFix: string) (source: string) =
+    async {
+        let ctx = getContext projectOptions source
+        let! msgs = noArgFormatStringCliAnalyzer ctx
+        Assert.That(msgs, Has.Length.EqualTo 1)
+        let msg = msgs[0]
+        Assert.That(Assert.messageContains message msg, Is.True)
+        Assert.That(msg.Fixes[0].ToText, Is.EqualTo expectedFix)
+    }
+
+let private assertNoMessages (source: string) =
+    async {
+        let ctx = getContext projectOptions source
+        let! msgs = noArgFormatStringCliAnalyzer ctx
+        Assert.That(msgs, Is.Empty)
+    }
+
+[<Test>]
+let ``sprintf with plain string`` () =
+    assertSingleFix
+        "\"<pre><code>\""
+        """module Lib
+let a = sprintf "<pre><code>"
+"""
+
+[<Test>]
+let ``sprintf with parenthesized string`` () =
+    assertSingleFix
+        "\"<pre><code>\""
+        """module Lib
+let a = sprintf ("<pre><code>")
+"""
+
+[<Test>]
+let ``sprintf with triple quoted string keeps the quotes`` () =
+    assertSingleFix
+        "\"\"\"<pre class=\"x\">\"\"\""
+        "module Lib
+let a = sprintf \"\"\"<pre class=\"x\">\"\"\"
+"
+
+[<Test>]
+let ``sprintf with verbatim string keeps the prefix`` () =
+    assertSingleFix
+        "@\"C:\\temp\""
+        """module Lib
+let a = sprintf @"C:\temp"
+"""
+
+[<Test>]
+let ``escaped percent is unescaped in the fix`` () =
+    assertSingleFix
+        "\"100%\""
+        """module Lib
+let a = sprintf "100%%"
+"""
+
+[<Test>]
+let ``qualified sprintf`` () =
+    assertSingleFix
+        "\"hello\""
+        """module Lib
+let a = Printf.sprintf "hello"
+"""
+
+[<Test>]
+let ``failwithf becomes failwith`` () =
+    assertSingleFix
+        "failwith \"boom\""
+        """module Lib
+let a () : int = failwithf "boom"
+"""
+
+[<Test>]
+let ``printfn becomes stdout.WriteLine`` () =
+    assertSingleFix
+        "stdout.WriteLine \"hello\""
+        """module Lib
+printfn "hello"
+"""
+
+[<Test>]
+let ``printf becomes stdout.Write`` () =
+    assertSingleFix
+        "stdout.Write \"hello\""
+        """module Lib
+printf "hello"
+"""
+
+[<Test>]
+let ``eprintfn becomes stderr.WriteLine`` () =
+    assertSingleFix
+        "stderr.WriteLine \"hello\""
+        """module Lib
+eprintfn "hello"
+"""
+
+[<Test>]
+let ``eprintf becomes stderr.Write`` () =
+    assertSingleFix
+        "stderr.Write \"hello\""
+        """module Lib
+eprintf "hello"
+"""
+
+[<Test>]
+let ``format specifier does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let a = sprintf "language-%s" "fsharp"
+"""
+
+[<Test>]
+let ``partially applied format specifier does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let a = sprintf "language-%s"
+"""
+
+[<Test>]
+let ``interpolated string does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let x = 1
+let a = sprintf $"value {x}"
+"""
+
+[<Test>]
+let ``user defined sprintf does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let sprintf (s: string) = s
+let a = sprintf "hello"
+"""
+
+[<Test>]
+let ``non literal format does not trigger`` () =
+    assertNoMessages
+        """module Lib
+let fmt = Printf.StringFormat<string> "hello"
+let a = sprintf fmt
+"""
+
+[<Test>]
+let ``sprintf with double parenthesized string`` () =
+    assertSingleFix
+        "\"<pre><code>\""
+        """module Lib
+let a = sprintf (("<pre><code>"))
+"""


### PR DESCRIPTION
Reports sprintf, failwithf, printf, printfn, eprintf and eprintfn applied to a constant format string that contains no format specifiers. The call still goes through the printf format parsing machinery on every invocation, while the plain string literal (or failwith, stdout.Write, stderr.Write) gives the same result without that cost.

A code fix replaces the call with the literal, unescaping %% to % and preserving verbatim and triple-quoted syntax.

Also make build.fsx executable with a dotnet fsi shebang, bump Fun.Build to 1.1.18 and pass extra arguments after "Docs" through to fsdocs watch.

See https://github.com/fsprojects/FSharp.Formatting/pull/1271